### PR TITLE
Add API endpoint for black and white video filter

### DIFF
--- a/Ffmpeg.API/DTOs/BlackAndWhiteDto.cs
+++ b/Ffmpeg.API/DTOs/BlackAndWhiteDto.cs
@@ -1,0 +1,8 @@
+﻿namespace FFmpeg.API.DTOs
+{
+    public class BlackAndWhiteDto
+    {
+        public IFormFile InputFile { get; set; }
+        public string OutputFileName { get; set; }
+    }
+}

--- a/Ffmpeg.API/Endpoints/VideoEndpoints.cs
+++ b/Ffmpeg.API/Endpoints/VideoEndpoints.cs
@@ -20,8 +20,70 @@ namespace FFmpeg.API.Endpoints
             app.MapPost("/api/video/watermark", AddWatermark)
                 .DisableAntiforgery()
                 .WithMetadata(new RequestSizeLimitAttribute(104857600)); // 100 MB
-        }
 
+            app.MapPost("/api/video/blackandwhite", AddBlackAndWhite)
+                .DisableAntiforgery()
+                .WithMetadata(new RequestSizeLimitAttribute(104857600));
+
+        }
+        private static async Task<IResult> AddBlackAndWhite(
+           HttpContext context,
+           [FromForm] BlackAndWhiteDto dto)
+        {
+            var fileService = context.RequestServices.GetRequiredService<IFileService>();
+            var ffmpegService = context.RequestServices.GetRequiredService<IFFmpegServiceFactory>();
+            var logger = context.RequestServices.GetRequiredService<ILogger<Program>>();
+
+            try
+            {
+                if (dto.InputFile == null)
+                {
+                    return Results.BadRequest("Input video file is required");
+                }
+
+                string videoFileName = await fileService.SaveUploadedFileAsync(dto.InputFile);
+                string outputFileName = dto.OutputFileName ?? await fileService.GenerateUniqueFileNameAsync(".mp4");
+
+                // Track files to clean up
+                List<string> filesToCleanup = new List<string> { videoFileName, outputFileName };
+
+                try
+                {
+                    // Create and execute the black-and-white command
+                    var command = ffmpegService.CreateBlackAndWhiteCommand();
+                    var result = await command.ExecuteAsync(new BlackAndWhiteModel
+                    {
+                        InputFile = videoFileName,
+                        OutputFile = outputFileName
+                    });
+
+                    if (!result.IsSuccess)
+                    {
+                        logger.LogError("FFmpeg command failed: {ErrorMessage}, Command: {Command}",
+                            result.ErrorMessage, result.CommandExecuted);
+                        return Results.Problem("Failed to apply black and white filter: " + result.ErrorMessage, statusCode: 500);
+                    }
+
+                    byte[] fileBytes = await fileService.GetOutputFileAsync(outputFileName);
+
+                    // Clean up temporary files
+                    _ = fileService.CleanupTempFilesAsync(filesToCleanup);
+
+                    return Results.File(fileBytes, "video/mp4", dto.OutputFileName);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Error processing black and white filter request");
+                    _ = fileService.CleanupTempFilesAsync(filesToCleanup);
+                    throw;
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error in AddBlackAndWhite endpoint");
+                return Results.Problem("An error occurred: " + ex.Message, statusCode: 500);
+            }
+        }
         private static async Task<IResult> AddWatermark(
             HttpContext context,
             [FromForm] WatermarkDto dto)


### PR DESCRIPTION
This PR implements the API for the black and white video filter feature.

Changes:
- Added `BlackAndWhiteDto` to handle input and output files for the black and white filter.
- Created an endpoint to process video files and apply the filter using FFmpeg.

This PR is part of the larger task of adding video processing features using FFmpeg.
