### PR TITLE
Add animated text command

### DIFF
--- a/FFmpeg.Core/Models/AnimatedTextModel.cs
+++ b/FFmpeg.Core/Models/AnimatedTextModel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFmpeg.Core.Models
+{
+    internal class AnimatedTextModel
+    {
+    }
+}

--- a/FFmpeg.Core/Models/AnimatedTextModel.cs
+++ b/FFmpeg.Core/Models/AnimatedTextModel.cs
@@ -6,7 +6,13 @@ using System.Threading.Tasks;
 
 namespace FFmpeg.Core.Models
 {
-    internal class AnimatedTextModel
+    public class AnimatedTextModel
     {
+        public string VideoPath { get; set; }
+        public string Text { get; set; }
+        public string Color { get; set; }
+        public int FontSize { get; set; }
+        public string OutputPath { get; set; }
     }
+
 }

--- a/FFmpeg.Infrastructure/Commands/AnimatedTextCommand.cs
+++ b/FFmpeg.Infrastructure/Commands/AnimatedTextCommand.cs
@@ -1,12 +1,42 @@
-﻿using System;
+﻿using FFmpeg.Core.Models;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace FFmpeg.Infrastructure.Commands
 {
-    internal class AnimatedTextCommand
+
+    public class AddAnimatedTextCommand
     {
+        private readonly string _ffmpegPath;
+
+        public AddAnimatedTextCommand(string ffmpegPath)
+        {
+            _ffmpegPath = ffmpegPath;
+        }
+
+        public void Execute(AnimatedTextModel model)
+        {
+            string arguments = $"-i \"{model.VideoPath}\" -vf \"drawtext=text='{model.Text}':x=100:y=50:fontsize={model.FontSize}:fontcolor={model.Color}\" \"{model.OutputPath}\"";
+
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                FileName = _ffmpegPath,
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            using (Process process = new Process { StartInfo = startInfo })
+            {
+                process.Start();
+                process.WaitForExit();
+            }
+        }
     }
 }

--- a/FFmpeg.Infrastructure/Commands/AnimatedTextCommand.cs
+++ b/FFmpeg.Infrastructure/Commands/AnimatedTextCommand.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFmpeg.Infrastructure.Commands
+{
+    internal class AnimatedTextCommand
+    {
+    }
+}

--- a/FFmpeg.Infrastructure/Services/FFmpegServiceFactory.cs
+++ b/FFmpeg.Infrastructure/Services/FFmpegServiceFactory.cs
@@ -20,6 +20,8 @@ namespace FFmpeg.Infrastructure.Services
     {
         private readonly FFmpegExecutor _executor;
         private readonly ICommandBuilder _commandBuilder;
+        private readonly string ffmpegPath;
+
 
         public FFmpegServiceFactory(IConfiguration configuration, ILogger logger = null)
         {
@@ -35,6 +37,10 @@ namespace FFmpeg.Infrastructure.Services
         public ICommand<WatermarkModel> CreateWatermarkCommand()
         {
             return new WatermarkCommand(_executor, _commandBuilder);
+        }
+        public AddAnimatedTextCommand CreateAddAnimatedTextCommand()
+        {
+            return new AddAnimatedTextCommand(ffmpegPath);
         }
     }
 }

--- a/Ffmpeg.API/DTOs/AnimatedTextDto.cs
+++ b/Ffmpeg.API/DTOs/AnimatedTextDto.cs
@@ -1,0 +1,11 @@
+﻿namespace FFmpeg.API.DTOs
+{
+    public class AnimatedTextDto
+    {
+        public string VideoName { get; set; }
+        public string TextContent { get; set; }
+        public string Color { get; set; }
+        public int FontSize { get; set; }
+        public string OutputName { get; set; }
+    }
+}

--- a/Ffmpeg.API/Endpoints/VideoEndpoints.cs
+++ b/Ffmpeg.API/Endpoints/VideoEndpoints.cs
@@ -15,12 +15,14 @@ namespace FFmpeg.API.Endpoints
 {
     public static class VideoEndpoints
     {
+
         public static void MapEndpoints(this WebApplication app)
         {
             app.MapPost("/api/video/watermark", AddWatermark)
                 .DisableAntiforgery()
                 .WithMetadata(new RequestSizeLimitAttribute(104857600)); // 100 MB
         }
+
 
         private static async Task<IResult> AddWatermark(
             HttpContext context,


### PR DESCRIPTION
## Description
This PR adds the functionality to overlay animated text on a video using FFmpeg.

### Changes included:
- Added `AddAnimatedTextCommand` in `FFmpeg.Infrastructure.Commands`.
- Added `AnimatedTextModel` in `FFmpeg.Core.Models`.
- Added `AddAnimatedTextDto` in `FFmpeg.API.DTOs`.
- Updated `FFmpegServiceFactory` to support the new command.

### Input required:
- Video name
- Text content
- Color
- Font size
- Output video name

---

Please review and provide feedback if needed.
